### PR TITLE
Handle invalid ElevenLabs key

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,8 +29,14 @@
     </footer>
 
     <script type="module">
-      import { narrate, toggleNarrator } from './narrator.js';
-      // === Narrator toggle button ===
+        import { narrate, toggleNarrator, setElevenKey } from './narrator.js';
+
+        // Use provided environment key if available
+        if (window.ELEVEN_API_KEY) {
+          setElevenKey(window.ELEVEN_API_KEY);
+        }
+
+        // === Narrator toggle button ===
 const narrBtn = document.createElement('button');
 narrBtn.textContent = '🎙 Narrator';
 narrBtn.className = 'fixed top-4 right-4 px-4 py-2 rounded-lg bg-yellow-700 text-gray-900 font-bold shadow-lg';
@@ -73,6 +79,19 @@ narrBtn.addEventListener('click', () => {
 
       // History state for context
       let history = [];
+      let currentTheme = '';
+
+      const SAVE_KEY = 'chaim_adventure_save';
+      function saveGame(state) {
+        localStorage.setItem(SAVE_KEY, JSON.stringify(state));
+      }
+      function loadGame() {
+        const raw = localStorage.getItem(SAVE_KEY);
+        return raw ? JSON.parse(raw) : null;
+      }
+      function clearSavedGame() {
+        localStorage.removeItem(SAVE_KEY);
+      }
 
       // Detect if ReadableStream uploads are supported
       function supportsReadableStreamUploads() {
@@ -185,6 +204,14 @@ narrBtn.addEventListener('click', () => {
             <button id="start-custom" class="w-full px-4 py-3 rounded-lg bg-gradient-to-r from-yellow-500 to-yellow-700 hover:from-yellow-400 hover:to-yellow-600 text-gray-900 font-semibold shadow-md transition-colors focus:outline-none">Start Custom Adventure</button>
           </div>
         `;
+        const saved = loadGame();
+        if (saved) {
+          const resume = document.createElement('button');
+          resume.id = 'resume';
+          resume.textContent = 'Continue Last Adventure';
+          resume.className = 'w-full max-w-2xl px-4 py-3 rounded-lg bg-gradient-to-r from-yellow-400 to-yellow-600 hover:from-yellow-300 hover:to-yellow-500 text-gray-900 font-semibold shadow-md transition-colors focus:outline-none';
+          container.appendChild(resume);
+        }
         app.appendChild(container);
         // Attach event listeners for suggested themes
         container.querySelectorAll('button[data-theme]').forEach(btn => {
@@ -204,6 +231,17 @@ narrBtn.addEventListener('click', () => {
           history = [];
           await startGame(custom);
         });
+        const resumeBtn = container.querySelector('#resume');
+        if (resumeBtn) {
+          resumeBtn.addEventListener('click', () => {
+            const saved = loadGame();
+            if (saved) {
+              history = saved.history || [];
+              currentTheme = saved.theme || '';
+              renderScene(saved.scene);
+            }
+          });
+        }
       }
 
       // Render loading screen
@@ -233,6 +271,7 @@ narrBtn.addEventListener('click', () => {
         `;
         app.appendChild(err);
         err.querySelector('#restart').addEventListener('click', () => {
+          clearSavedGame();
           renderHome();
         });
       }
@@ -278,18 +317,24 @@ function renderScene(scene) {
         )
         .join('')}
     </div>
+    <div class="text-right">
+      <button id="quit" class="text-yellow-400 underline">Quit to Home</button>
+    </div>
   `;
 
-
-
   app.appendChild(wrapper);
+  saveGame({ theme: currentTheme, history, scene });
 
   wrapper.querySelectorAll('button[data-idx]').forEach((btn) => {
     btn.addEventListener('click', async (e) => {
-      const index  = parseInt(e.currentTarget.getAttribute('data-idx'), 10);
+      const index = parseInt(e.currentTarget.getAttribute('data-idx'), 10);
       const choice = scene.choices[index].text;
       await handleChoice(choice);
     });
+  });
+  wrapper.querySelector('#quit').addEventListener('click', () => {
+    clearSavedGame();
+    renderHome();
   });
 }
 
@@ -308,6 +353,9 @@ function renderScene(scene) {
             { role: 'model', parts: [{ text: response.text }] },
           ];
           const scene = { ...geminiResponse, imageBase64 };
+          currentTheme = theme;
+          clearSavedGame();
+          saveGame({ theme: currentTheme, history, scene });
           renderScene(scene);
         } catch (err) {
           console.error(err);
@@ -342,6 +390,7 @@ function renderScene(scene) {
             { role: 'model', parts: [{ text: response.text }] },
           ];
           const scene = { ...geminiResponse, imageBase64 };
+          saveGame({ theme: currentTheme, history, scene });
           renderScene(scene);
         } catch (err) {
           console.error(err);


### PR DESCRIPTION
## Summary
- ensure stored key is trimmed and updated when narrator is toggled
- clear local storage and alert the user when the key is rejected
- show a browser alert for unexpected narrator errors
- use the ElevenLabs API key from the environment without prompting
- add resume support so adventures can be continued later

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68828e95e7e4832a9c613f83d1709624