### PR TITLE
[Feature] Mobile fallback for narration

### DIFF
--- a/narrator.js
+++ b/narrator.js
@@ -54,14 +54,19 @@ async function streamChunk(chunk) {
   if (!res.ok) throw new Error('TTS failed: ' + res.status);
 
   // assemble streamed audio into a blob
-  const reader = res.body.getReader();
-  const parts  = [];
-  while (true) {
-    const { done, value } = await reader.read();
-    if (done) break;
-    parts.push(value);
+  let blob;
+  if (res.body && res.body.getReader) {
+    const reader = res.body.getReader();
+    const parts  = [];
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      parts.push(value);
+    }
+    blob = new Blob(parts, { type: 'audio/mpeg' });
+  } else {
+    blob = await res.blob();
   }
-  const blob  = new Blob(parts, { type: 'audio/mpeg' });
   const audio = new Audio(URL.createObjectURL(blob));
 
   // play completely before returning (prevents overlaps)


### PR DESCRIPTION
## Summary
- handle cases where `fetch` streaming isn't available in `narrator.js`

## Testing
- `curl -s http://localhost:8000/index.html | head -n 5`
- `node test.js` *(fails: `Error: Cannot find module`)*
- `apt-get update` *(partial failure: blocked domain)*

------
https://chatgpt.com/codex/tasks/task_e_6882ab965b40832a81d0cc13701c8b15